### PR TITLE
Don't rely on globally scoped variables

### DIFF
--- a/Dictionaries and Sets/proofOfConcept.js
+++ b/Dictionaries and Sets/proofOfConcept.js
@@ -20,7 +20,7 @@ function createLast(word) {
 };
 
 //find the Term within the Set
-function findThatTerm(setToSearch) {
+function findThatTerm(setToSearch, searchTermFirst, searchTermLast) {
     var hasFirstLetter = setToSearch.has(searchTermFirst);
     var hasLastLetter = setToSearch.has(searchTermLast);
     if (hasFirstLetter && hasLastLetter) {
@@ -44,4 +44,4 @@ var searchTermFirst = createFirst(searchTerm);
 var searchTermLast = createLast(searchTerm);
 
 //look for them
-findThatTerm(bitmap)
+findThatTerm(bitmap, searchTermFirst, searchTermLast)


### PR DESCRIPTION
Lines 24 and 25 were previously relying on variables defined outside the scope of the function those lines are in. I've made a small change to explicitly pass in the needed information, rather than rely on the global scope.